### PR TITLE
Update Godot Android Library to use the stable version: 4.2.0.stable

### DIFF
--- a/config.gradle
+++ b/config.gradle
@@ -1,6 +1,3 @@
-final snapshotGodotAndroidLib = "org.godotengine:godot:4.2.0.rc-SNAPSHOT"
-final stableGodotAndroidLib = "org.godotengine:godot:4.2.0.stable"
-
 ext {
     versions = [
             gradlePluginVersion: '7.4.0',
@@ -12,7 +9,6 @@ ext {
     ]
 
     libraries = [
-            // TODO: Update the godot dep when 4.2 is stable
-            godotAndroidLib: snapshotGodotAndroidLib,
+            godotAndroidLib: "org.godotengine:godot:4.2.0.stable",
     ]
 }


### PR DESCRIPTION
This update aligns the project with the stable version of Godot (4.2.0.stable), ensuring better stability and compatibility. Fix m4gr3d/Godot-Android-Samples/#6